### PR TITLE
Bug fix and code refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(qt-music-player VERSION 0.1 LANGUAGES CXX)
+project(bragii VERSION 0.1 LANGUAGES CXX)
 
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOMOC ON)
@@ -29,6 +29,7 @@ set(PROJECT_SOURCES
     src/ui/emptysongdirdialog.ui
     src/ui/mainwindow.cpp
     src/ui/mainwindow.ui
+    src/ui/title_controller.cpp
     src/utils/filesys.cpp
     src/utils/network.cpp
     src/utils/string.cpp
@@ -36,26 +37,26 @@ set(PROJECT_SOURCES
 )
 
 if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
-    qt_add_executable(qt-music-player
+    qt_add_executable(bragii
         MANUAL_FINALIZATION
         ${PROJECT_SOURCES}
     )
 else()
     if(ANDROID)
-        add_library(qt-music-player SHARED
+        add_library(bragii SHARED
             ${PROJECT_SOURCES}
         )
     else()
-        add_executable(qt-music-player
+        add_executable(bragii
             ${PROJECT_SOURCES}
         )
     endif()
 endif()
 
 set(LIBS dl pthread OpenSSL::SSL OpenSSL::Crypto TagLib::tag TagLib::tag_c TagLib::TagLib ZLIB::ZLIB)
-target_link_libraries(qt-music-player PRIVATE Qt${QT_VERSION_MAJOR}::Widgets ${LIBS})
+target_link_libraries(bragii PRIVATE Qt${QT_VERSION_MAJOR}::Widgets ${LIBS})
 
-set_target_properties(qt-music-player PROPERTIES
+set_target_properties(bragii PROPERTIES
     MACOSX_BUNDLE_GUI_IDENTIFIER my.example.com
     MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
     MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
@@ -63,7 +64,7 @@ set_target_properties(qt-music-player PROPERTIES
     WIN32_EXECUTABLE TRUE
 )
 
-install(TARGETS qt-music-player
+install(TARGETS bragii
     BUNDLE DESTINATION .
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
@@ -78,5 +79,5 @@ add_custom_command(
 )
 
 if(QT_VERSION_MAJOR EQUAL 6)
-    qt_finalize_executable(qt-music-player)
+    qt_finalize_executable(bragii)
 endif()

--- a/CMakeLists.txt.user
+++ b/CMakeLists.txt.user
@@ -175,9 +175,9 @@
     <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
     <value type="bool" key="PE.EnvironmentAspect.PrintOnRun">false</value>
     <value type="QString" key="PerfRecordArgsId">-e cpu-cycles --call-graph dwarf,4096 -F 250</value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">qt-music-player</value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.CMakeRunConfiguration.qt-music-player</value>
-    <value type="QString" key="ProjectExplorer.RunConfiguration.BuildKey">qt-music-player</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">bragii</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.CMakeRunConfiguration.bragii</value>
+    <value type="QString" key="ProjectExplorer.RunConfiguration.BuildKey">bragii</value>
     <value type="bool" key="ProjectExplorer.RunConfiguration.Customized">false</value>
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
     <value type="bool" key="RunConfiguration.UseLibrarySearchPath">true</value>

--- a/devscripts/run.sh
+++ b/devscripts/run.sh
@@ -5,4 +5,4 @@ BUILD_DIR="build"
 [ ! -d $BUILD_DIR ] && mkdir $BUILD_DIR
 cd $BUILD_DIR
 
-cmake .. && ninja && ./qt-music-player
+cmake .. && ninja && ./bragii

--- a/src/ui/mainwindow.hpp
+++ b/src/ui/mainwindow.hpp
@@ -17,6 +17,7 @@
 #include "../modules/songs_manager/songs_manager.hpp"
 #include "download_song_dialog.hpp"
 #include "empty_song_dir_dialog.hpp"
+#include "title_controller.hpp"
 
 
 QT_BEGIN_NAMESPACE
@@ -58,7 +59,7 @@ private:
     void change_song(size_t song_idx);
     void play_song();
     void change_directory(std::string dir);
-    void make_moving_title();
+    void update_cover_art();
 
     Ui::MainWindow* m_ui;
     QLabel* m_song_title_label;
@@ -72,8 +73,6 @@ private:
     QSlider* m_song_slider;
     QLabel* m_graphics_label;
     QLabel* m_background;
-    QTimer* m_title_timer; // Timer used for making moving title
-    QTimer* m_single_shot_timer; // Timer used for single shot purpose
 
     DownloadSongDialog* m_download_song_dialog;
     EmptySongDirDialog* m_empty_song_dir_dialog;
@@ -83,6 +82,7 @@ private:
 
     size_t m_current_song_idx;
     SongsManager* m_songs_manager;
+    TitleController* m_title_controller;
     bool m_is_replaying;
     std::string m_current_dir;
 };

--- a/src/ui/title_controller.cpp
+++ b/src/ui/title_controller.cpp
@@ -1,0 +1,68 @@
+#include "title_controller.hpp"
+
+#include <unistd.h>
+
+
+#define SEC_TO_MICROSEC(s) s * 1000000
+
+
+TitleController::TitleController(QLabel* title_widget) :
+            m_title_widget(title_widget),
+            m_no_animation(true),
+            m_stop(false),
+            m_hold(true) {}
+
+TitleController::~TitleController() {
+    m_stop = true;
+    usleep(SEC_TO_MICROSEC(0.2));
+}
+
+inline bool
+needs_animation(QLabel* title_widget, std::string title) {
+    return title_widget->fontMetrics().width(title.c_str()) >= title_widget->width();
+}
+
+void
+TitleController::change_title(std::string new_title) {
+    m_no_animation = !needs_animation(m_title_widget, new_title);
+
+    m_hold = true;
+    m_hold_time_left = SEC_TO_MICROSEC(2);
+    usleep(SEC_TO_MICROSEC(0.2));
+
+    if (m_no_animation) {
+        m_title_widget->setText(new_title.c_str());
+        m_title_widget->setAlignment(Qt::AlignCenter);
+        return;
+    }
+    size_t extra_space_count =
+            m_title_widget->width() / QFontMetrics(m_title_widget->font()).width(' ');
+    m_title_widget->setText((new_title + std::string(extra_space_count, ' ')).c_str());
+    m_title_widget->setAlignment(Qt::AlignLeft);
+}
+
+void
+TitleController::run() {
+    while (!m_stop) {
+        if (m_no_animation) {
+            usleep(SEC_TO_MICROSEC(0.2));
+            continue;
+        }
+        if (m_hold) {
+            size_t sleep_time = SEC_TO_MICROSEC(0.2);
+            m_hold_time_left -= sleep_time;
+            if (m_hold_time_left <= 0) {
+                m_hold = false;
+            } else {
+                usleep(sleep_time);
+                continue;
+            }
+        }
+        // Make moving title
+        usleep(SEC_TO_MICROSEC(0.2));
+        QString text = m_title_widget->text();
+        text.push_back(text.front());
+        text.remove(0, 1);
+        m_title_widget->setText(text);
+    }
+}

--- a/src/ui/title_controller.hpp
+++ b/src/ui/title_controller.hpp
@@ -1,0 +1,30 @@
+#ifndef TITLE_CONTROLLER_HPP
+#define TITLE_CONTROLLER_HPP
+
+#include <QLabel>
+#include <QThread>
+#include <QTimer>
+
+#include <string>
+
+class TitleController : public QThread {
+    Q_OBJECT
+
+public:
+    TitleController(QLabel* title_widget);
+
+    ~TitleController();
+
+    void change_title(std::string new_title);
+
+private:
+    void run();
+
+    QLabel* m_title_widget;
+    bool m_stop;
+    bool m_no_animation;
+    bool m_hold;
+    long m_hold_time_left;
+};
+
+#endif // TITLE_CONTROLLER_HPP


### PR DESCRIPTION
- Fix crash due to QTimer being called in a different thread. Previously, we use QTimer to create moving title feature. And the timer will be stopped/started when there's a song change. When song change is triggered by user (next click, prev click, or song list click), QTimer is stopped/started by the main thread. But when song change is triggered by SongsManager when song ends, it is in a different thread. Hence, the crash. We got rid of the QTimer in this commit and create the moving title effect using a while loop instead.
- Application name is now officially "Bragii", which is taken from the name of the god of music in Norse mythology - Bragi.
- Add JSON response check when making call to MusicBrainz API.
- Some code refactor in mainwindow.{hpp/cpp}